### PR TITLE
Fix bug with inputs that are a multiple of 5

### DIFF
--- a/src/accessory.television.js
+++ b/src/accessory.television.js
@@ -149,7 +149,7 @@ class TelevisionAccessory extends Accessory {
 
         this.platform.debug(`switching to ${this.type} input ${this.input.name} [${this.input.identifier}] for accessory (${this.device.name} [${this.device.uid}]).`);
 
-        let column = this.input.index % 5;
+        let column = this.input.index % 5 || 5;
         let row = (this.input.index - column) / 5;
 
         await this.device.sendKeyCommand(appletv.AppleTV.Key.Tv);


### PR DESCRIPTION
There was a simple logic error causing #35 

Critically, the column calculation allowed for a value of 0, which actually indicates 5.